### PR TITLE
#744: review submit now has separate render and submit methods in public API

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,6 +38,24 @@ class MultiReviewSubmissionApp(sgtk.platform.Application):
         """
         return True
 
+    def get_resolved_write_nodes(self, fields):
+        """
+        Returns the resolved paths of the write nodes that the app should run/use from the nuke file.
+        """
+
+        resolved_mapping = {}
+        extra_write_nodes_path_info = self.get_setting("extra_write_nodes_path_info")
+
+        if extra_write_nodes_path_info:
+            for write_node_name, write_node_template_name in extra_write_nodes_path_info.iteritems():
+                # resolve the path from the template
+                write_node_template = self.get_template_by_name(write_node_template_name)
+                write_node_path = write_node_template.apply_fields(fields)
+
+                resolved_mapping[write_node_name] = write_node_path
+
+        return resolved_mapping
+
     def render_and_submit(self, template, fields, first_frame, last_frame, sg_publishes, sg_task,
                           comment, thumbnail_path, progress_cb):
         """
@@ -52,12 +70,62 @@ class MultiReviewSubmissionApp(sgtk.platform.Application):
         return self.render_and_submit_version(template, fields, first_frame, last_frame, sg_publishes, sg_task,
                                   comment, thumbnail_path, progress_cb)
 
-    def render_and_submit_version(self, template, fields, first_frame, last_frame, sg_publishes, sg_task,
-                                  comment, thumbnail_path, progress_cb, color_space=None, *args, **kwargs):
+    def render_and_return_paths(self, path, fields, first_frame, last_frame, sg_publishes, sg_task,
+                                comment, thumbnail_path, progress_cb, color_space=None, *args, **kwargs):
         """
-        Main application entry point to be called by other applications / hooks.
+        Render and return the paths that are processed by the nuke hook.
 
-        :param template:        The template defining the path where frames should be found.
+        :param path:            The path where frames should be found.
+        :param fields:          Dictionary of fields to be used to fill out the template with.
+        :param first_frame:     The first frame of the sequence of frames.
+        :param last_frame:      The last frame of the sequence of frames.
+        :param sg_publishes:    A list of shotgun published file objects to link the publish against.
+        :param sg_task:         A Shotgun task object to link against. Can be None.
+        :param comment:         A description to add to the Version in Shotgun.
+        :param thumbnail_path:  The path to a thumbnail to use for the version when the movie isn't
+                                being uploaded to Shotgun (this is set in the config)
+        :param progress_cb:     A callback to report progress with.
+        :param color_space:     The colorspace of the rendered frames
+
+        :returns:               List of processed paths that have been rendered by the nuke hook.
+        """
+
+        tk_multi_reviewsubmission = self.import_module("tk_multi_reviewsubmission")
+
+        progress_cb(10, "Preparing...")
+
+        extra_write_node_mapping = self.get_resolved_write_nodes(fields)
+
+        # Make sure we don't overwrite the caller's fields
+        fields = copy.copy(fields)
+
+        # Movie output width and height
+        width = self.get_setting("movie_width")
+        height = self.get_setting("movie_height")
+        fields["width"] = width
+        fields["height"] = height
+
+        # Get an output path for the movie.
+        output_path_template = self.get_template("movie_path_template")
+        output_path = output_path_template.apply_fields(fields)
+
+        fields["description"] = comment
+
+        # Render and Submit
+        renderer = tk_multi_reviewsubmission.Renderer()
+        processed_paths = renderer.render_movie_in_nuke(path, output_path, extra_write_node_mapping, width, height,
+                                                        first_frame, last_frame, fields.get("version", 0),
+                                                        fields.get("name", "Unnamed"), color_space, fields, progress_cb)
+
+        return processed_paths
+
+    def submit_version(self, path, path_to_upload, fields, first_frame, last_frame, sg_publishes, sg_task,
+                       comment, thumbnail_path, progress_cb, color_space=None, *args, **kwargs):
+        """
+        Create a version entity for the given path.
+
+        :param path:            The path where frames should be found.
+        :param path_to_upload:  The path to create the version entity for.
         :param fields:          Dictionary of fields to be used to fill out the template with.
         :param first_frame:     The first frame of the sequence of frames.
         :param last_frame:      The last frame of the sequence of frames.
@@ -71,22 +139,55 @@ class MultiReviewSubmissionApp(sgtk.platform.Application):
 
         :returns:               The Version Shotgun entity dictionary that was created.
         """
+
+        tk_multi_reviewsubmission = self.import_module("tk_multi_reviewsubmission")
+
+        # Is the app configured to do anything?
+        upload_to_shotgun = self.get_setting("upload_to_shotgun")
+        store_on_disk = self.get_setting("store_on_disk")
+        if not upload_to_shotgun and not store_on_disk:
+            self.log_warning("App is not configured to store images on disk nor upload to shotgun!")
+            return None
+
         # Make sure we don't overwrite the caller's fields
         fields = copy.copy(fields)
 
-        # Tweak fields so that we'll be getting nuke formatted sequence markers (%03d, %04d etc):
-        for key_name in [key.name for key in template.keys.values() if isinstance(key, sgtk.templatekey.SequenceKey)]:
-            fields[key_name] = "FORMAT: %d"
+        # Get the name for the Version entity
+        version_template = self.get_template("sg_version_name_template")
+        version_name = None
+        if version_template:
+            version_name = version_template.apply_fields(fields)
 
-        # Get our input path for frames to convert to movie
-        path = template.apply_fields(fields)
+        # Submit Version
+        progress_cb(50, "Creating Shotgun Version and uploading movie")
+        submitter = tk_multi_reviewsubmission.Submitter()
+        sg_version = submitter.submit_version(path,
+                                              path_to_upload,
+                                              thumbnail_path,
+                                              sg_publishes,
+                                              sg_task,
+                                              comment,
+                                              store_on_disk,
+                                              first_frame,
+                                              last_frame,
+                                              upload_to_shotgun,
+                                              version_name)
 
-        # call new version
-        return self.render_and_submit_path(path, fields, first_frame, last_frame, sg_publishes, sg_task,
-                                  comment, thumbnail_path, progress_cb, color_space, *args, **kwargs)
+        # Remove from filesystem if required
+        if not store_on_disk and os.path.exists(path_to_upload):
+            progress_cb(90, "Deleting rendered movie")
+            os.unlink(path_to_upload)
 
+        # log metrics for this app's usage
+        try:
+            self.log_metric("Render & Submit Version", log_version=True)
+        except:
+            # ignore any errors. ex: metrics logging not supported
+            pass
 
-    def render_and_submit_path(self, path, fields, first_frame, last_frame, sg_publishes, sg_task,
+        return sg_version
+
+    def render_and_submit_version(self, path, fields, first_frame, last_frame, sg_publishes, sg_task,
                                   comment, thumbnail_path, progress_cb, color_space=None, *args, **kwargs):
         """
         Main application entry point to be called by other applications / hooks.
@@ -114,20 +215,8 @@ class MultiReviewSubmissionApp(sgtk.platform.Application):
             self.log_warning("App is not configured to store images on disk nor upload to shotgun!")
             return None
 
-        progress_cb(10, "Preparing")
-
         # Make sure we don't overwrite the caller's fields
         fields = copy.copy(fields)
-
-        # Movie output width and height
-        width = self.get_setting("movie_width")
-        height = self.get_setting("movie_height")
-        fields["width"] = width
-        fields["height"] = height
-
-        # Get an output path for the movie.
-        output_path_template = self.get_template("movie_path_template")
-        output_path = output_path_template.apply_fields(fields)
 
         # Get the name for the Version entity
         version_template = self.get_template("sg_version_name_template")
@@ -135,19 +224,15 @@ class MultiReviewSubmissionApp(sgtk.platform.Application):
         if version_template:
             version_name = version_template.apply_fields(fields)
 
-        fields["description"] = comment
+        # get processed path
+        progress_cb(20, "Rendering Movie...")
+        processed_paths = self.render_and_return_paths(path, fields, first_frame, last_frame, sg_publishes, sg_task,
+                                                       comment, thumbnail_path, progress_cb, color_space, *args, **kwargs)
 
-        # Render and Submit
-        progress_cb(20, "Rendering movie")
-        renderer = tk_multi_reviewsubmission.Renderer()
-        renderer.render_movie_in_nuke(path, 
-                                      output_path, 
-                                      width, height, 
-                                      first_frame, last_frame,
-                                      fields.get("version", 0), 
-                                      fields.get("name", "Unnamed"),
-                                      color_space, fields)
+        assert len(processed_paths) == 1, "Can't create versions for more than one files!"
+        output_path = processed_paths[0]
 
+        # Submit Version
         progress_cb(50, "Creating Shotgun Version and uploading movie")
         submitter = tk_multi_reviewsubmission.Submitter()
         sg_version = submitter.submit_version(path, 
@@ -171,7 +256,7 @@ class MultiReviewSubmissionApp(sgtk.platform.Application):
         try:
             self.log_metric("Render & Submit Version", log_version=True)
         except:
-            # ingore any errors. ex: metrics logging not supported
+            # ignore any errors. ex: metrics logging not supported
             pass
 
         return sg_version

--- a/app.py
+++ b/app.py
@@ -229,8 +229,21 @@ class MultiReviewSubmissionApp(sgtk.platform.Application):
         processed_paths = self.render_and_return_paths(path, fields, first_frame, last_frame, sg_publishes, sg_task,
                                                        comment, thumbnail_path, progress_cb, color_space, *args, **kwargs)
 
-        assert len(processed_paths) == 1, "Can't create versions for more than one files!"
-        output_path = processed_paths[0]
+        # Make sure we don't overwrite the caller's fields
+        fields = copy.copy(fields)
+
+        # Movie output width and height
+        width = self.get_setting("movie_width")
+        height = self.get_setting("movie_height")
+        fields["width"] = width
+        fields["height"] = height
+
+        # Get an output path for the movie.
+        output_path_template = self.get_template("movie_path_template")
+        output_path = output_path_template.apply_fields(fields)
+
+        if output_path not in processed_paths:
+            raise Exception("tk-multi-reviewsubmission not configured to render movie!")
 
         # Submit Version
         progress_cb(50, "Creating Shotgun Version and uploading movie")

--- a/hooks/nuke_batch_render_movie.py
+++ b/hooks/nuke_batch_render_movie.py
@@ -59,27 +59,30 @@ def __create_output_node(path, codec_settings, logger=None):
     return node
 
 
-def render_movie_in_nuke(path, output_path, extra_write_node_mapping,
-                         width, height,
-                         first_frame, last_frame,
-                         version, name,
-                         color_space,
-                         app_settings,
-                         ctx, render_info,
-                         is_subprocess=False):
+def render_in_nuke(path_to_frames, path_to_movie, extra_write_node_mapping, width, height, first_frame, last_frame,
+                   version, name, color_space, app_settings, ctx, render_info, is_subprocess=False):
     """
     Use Nuke to render a movie. This assumes we're running _inside_ Nuke.
 
-    :param path:        Path to the input frames for the movie
-    :param output_path: Path to the output movie that will be rendered
-    :param width:       Width of the output movie
-    :param height:      Height of the output movie
-    :param first_frame: Start frame for the output movie
-    :param last_frame:  End frame for the output movie
-    :param version:     Version number to use for the output movie slate and burn-in
-    :param name:        Name to use in the slate for the output movie
-    :param color_space: Colorspace of the input frames
+    :param path_to_frames: Path to the input frames for the movie
+    :param path_to_movie:  Path to the output movie that will be rendered
+    :param extra_write_node_mapping: Mapping of write nodes with their output paths that should be rendered,
+        other than the movie write node
+    :param width:          Width of the output movie
+    :param height:         Height of the output movie
+    :param first_frame:    Start frame for the output movie
+    :param last_frame:     End frame for the output movie
+    :param version:        Version number to use for the output movie slate and burn-in
+    :param name:           Name to use in the slate for the output movie
+    :param color_space:    Colorspace of the input frames
+    :param app_settings:   Settings of the app like slate_logo, version padding etc.
+    :param ctx:            context object for which the render is supposed to run
+    :param render_info:    Burnin nuke file to be used as template, codec settings for the movie.
+    :param is_subprocess:  If it's subprocess or not
+
+    :return:               Status of the nuke script execution
     """
+
     output_node = None
     root_node = nuke.root()
 
@@ -96,7 +99,7 @@ def render_movie_in_nuke(path, output_path, extra_write_node_mapping,
 
     try:
         # create read node
-        read = nuke.nodes.Read(name="source", file=path.replace(os.sep, "/"))
+        read = nuke.nodes.Read(name="source", file=path_to_frames.replace(os.sep, "/"))
         read["on_error"].setValue("black")
         read["first"].setValue(first_frame)
         read["last"].setValue(last_frame)
@@ -169,25 +172,25 @@ def render_movie_in_nuke(path, output_path, extra_write_node_mapping,
         scale.setInput(0, burn)
 
         # Create the output node
-        output_node = __create_output_node(output_path, render_info.get('codec_settings', {}))
+        output_node = __create_output_node(path_to_movie, render_info.get('codec_settings', {}))
         output_node.setInput(0, scale)
     except:
         return {'status': 'ERROR', 'error_msg': '{0}'.format(traceback.format_exc()),
-                'output_path': output_path}
+                'output_path': path_to_movie}
 
     group.end()
 
     if output_node:
         try:
             # Make sure the output folder exists
-            output_folder = os.path.dirname(output_path)
+            output_folder = os.path.dirname(path_to_movie)
             ensure_folder_exists(output_folder)
 
             # Render the outputs, first view only
             nuke.executeMultiple([output_node], ([first_frame - 1, last_frame, 1],), [nuke.views()[0]])
         except:
             return {'status': 'ERROR', 'error_msg': '{0}'.format(traceback.format_exc()),
-                    'output_path': output_path}
+                    'output_path': path_to_movie}
 
     # Cleanup after ourselves
     nuke.delete(group)
@@ -199,8 +202,8 @@ def get_usage():
     return '''
   Usage: python {0} [ OPTIONS ]
          -h | --help ... print this usage message and exit.
-         --path <FRAME_PATH> ... specify full path to frames, with frame spec ... e.g. ".%04d.exr"
-         --output_path <OUTPUT_MOVIE_PATH> ... specify full path to output movie
+         --path_to_frames <FRAME_PATH> ... specify full path to frames, with frame spec ... e.g. ".%04d.exr"
+         --path_to_movie <OUTPUT_MOVIE_PATH> ... specify full path to output movie
          --extra_write_node_mapping <EXTRA_WRITE_NODE_MAPPING> ... mapping of extra write nodes to their output paths
          --width <WIDTH> ... specify width for output movie
          --height <HEIGHT> ... specify height for output movie
@@ -218,7 +221,7 @@ def get_usage():
 if __name__ == '__main__':
     # TODO: copied maquino's code. Refactor?
     data_keys = [
-        'path', 'output_path', 'extra_write_node_mapping', 'width', 'height', 'first_frame', 'last_frame',
+        'path_to_frames', 'path_to_movie', 'extra_write_node_mapping', 'width', 'height', 'first_frame', 'last_frame',
         'version', 'name', 'color_space', 'app_settings', 'shotgun_context', 'render_info',
     ]
 
@@ -252,16 +255,11 @@ if __name__ == '__main__':
 
     # Hack to ensure all output/error from this process can be captured when called as subprocess
     print ''
-    ret_status = render_movie_in_nuke(input_data['path'], input_data['output_path'],
-                                      input_data['extra_write_node_mapping'],
-                                      input_data['width'], input_data['height'],
-                                      input_data['first_frame'], input_data['last_frame'],
-                                      input_data['version'], input_data['name'],
-                                      input_data['color_space'],
-                                      input_data['app_settings'],
-                                      input_data['shotgun_context'],
-                                      input_data['render_info'],
-                                      is_subprocess=True)
+    ret_status = render_in_nuke(input_data['path_to_frames'], input_data['path_to_movie'],
+                                input_data['extra_write_node_mapping'], input_data['width'], input_data['height'],
+                                input_data['first_frame'], input_data['last_frame'], input_data['version'],
+                                input_data['name'], input_data['color_space'], input_data['app_settings'],
+                                input_data['shotgun_context'], input_data['render_info'], is_subprocess=True)
 
     sys.stderr.write('')
     sys.stderr.write('[RETURN_STATUS_DATA]{0}[RETURN_STATUS_DATA]'.format(ret_status))

--- a/info.yml
+++ b/info.yml
@@ -41,6 +41,17 @@ configuration:
                      as a temporary location for processing before the file is
                      uploaded to Shotgun.
 
+    extra_write_nodes_path_info:
+        type: dict
+        description: Dictionary containing a mapping of Write node names
+                     to their corresponding output paths in the form of templates.
+        allows_empty: True
+        values:
+          type: template
+          fields: context, version, [output], [name], *
+          description: Output path of the Write nodes
+          allows_empty: False
+
     movie_width:
         type: int
         default_value: 1024

--- a/python/tk_multi_reviewsubmission/renderer.py
+++ b/python/tk_multi_reviewsubmission/renderer.py
@@ -58,8 +58,26 @@ class Renderer(object):
             self._logo = self._logo.replace(os.sep, "/")
             self._burnin_nk = self._burnin_nk.replace(os.sep, "/")
 
-    def gather_nuke_render_info(self, path, output_path, extra_write_node_mapping, width, height, first_frame,
-                                last_frame, version, name, color_space, burnin_nk):
+    def gather_nuke_render_info(self, path_to_frames, path_to_movie, extra_write_node_mapping, width, height,
+                                first_frame, last_frame, version, name, color_space, burnin_nk):
+        """
+        Prepares the render settings for the nuke subprocess hook
+
+        :param path_to_frames:  The path where frames should be found.
+        :param path_to_movie:   The path where the movie should be written to
+        :param extra_write_node_mapping: Mapping of write nodes with their output paths that should be rendered,
+        other than the movie write node
+        :param width:       Movie width
+        :param height:      Movie height
+        :param first_frame: The first frame of the sequence of frames
+        :param last_frame:  The last frame of the sequence of frames
+        :param version:     Version currently being published
+        :param name:        Name of the file being published
+        :param color_space: Colorspace used to create the frames
+        :param burnin_nk:   Path to the nuke file to be used for processing
+
+        :return:            Dictionary of settings to be used by the subprocess.
+        """
         # First get Nuke executable path from project configuration environment
         setting_key_by_os = {'win32': 'nuke_windows_path',
                              'linux2': 'nuke_linux_path',
@@ -96,8 +114,8 @@ class Renderer(object):
         }
 
         # set needed paths and force them to use forward slashes for use in Nuke (for Windows)
-        src_frames_path = path.replace('\\', '/')
-        movie_output_path = output_path.replace('\\', '/')
+        src_frames_path = path_to_frames.replace('\\', '/')
+        movie_output_path = path_to_movie.replace('\\', '/')
 
         nuke_render_info = {
             'width': width,
@@ -118,15 +136,16 @@ class Renderer(object):
         }
         return nuke_render_info
 
-    def render_movie_in_nuke(self, path, output_path, extra_write_node_mapping, width, height, first_frame, last_frame,
-                             version, name, color_space, fields=None, active_progress_info=None):
+    def render_in_nuke(self, path_to_frames, path_to_movie, extra_write_node_mapping, width, height, first_frame,
+                       last_frame, version, name, color_space, fields=None, active_progress_info=None):
         """
         Renders the movie using a Nuke subprocess,
         along with slate/burnins using all the app settings.
 
-        :param path:            The path where frames should be found.
-        :param output_path:     The path where the movie should be written to
-        :param extra_write_node_mapping: Mapping of write nodes other than the movie write node with their output paths
+        :param path_to_frames:  The path where frames should be found.
+        :param path_to_movie:   The path where the movie should be written to
+        :param extra_write_node_mapping: Mapping of write nodes with their output paths that should be rendered,
+        other than the movie write node
         :param width:           Movie width
         :param height:          Movie height
         :param first_frame:     The first frame of the sequence of frames
@@ -141,7 +160,7 @@ class Renderer(object):
         # add to information passed for preprocessing
         fields["first_frame"] = first_frame
         fields["last_frame"] = last_frame
-        fields["path"] = path
+        fields["path"] = path_to_frames
 
         # preprocess self._burnin_nk to replace tokens
         processed_nuke_script_path = self.__app.execute_hook_method("preprocess_nuke_hook",
@@ -149,8 +168,8 @@ class Renderer(object):
                                                                     nuke_script_path=self._burnin_nk,
                                                                     fields=fields)
 
-        render_info = self.gather_nuke_render_info(path, output_path, extra_write_node_mapping, width, height,
-                                                   first_frame, last_frame, version, name, color_space,
+        render_info = self.gather_nuke_render_info(path_to_frames, path_to_movie, extra_write_node_mapping, width,
+                                                   height, first_frame, last_frame, version, name, color_space,
                                                    processed_nuke_script_path)
         run_in_batch_mode = True if nuke is None else False
 
@@ -181,8 +200,8 @@ class Renderer(object):
             # in the render hook we expect the thread to return us ':' separated paths
             # return a list of paths
             processed_paths_list = processed_paths.split(":")
-            for path in processed_paths_list:
-                active_progress_info(msg="Created %s" % path, stage={"item": {"name": "Render"},
+            for path_to_frames in processed_paths_list:
+                active_progress_info(msg="Created %s" % path_to_frames, stage={"item": {"name": "Render"},
                                                                      "output": {"name": "Nuke"}})
             return processed_paths_list
 
@@ -210,8 +229,8 @@ class ShooterThread(QtCore.QThread):
 
         cmd_and_args = [
             self.render_info['nuke_exe_path'], nuke_flag, self.render_info['render_script_path'],
-            '--path', pickle.dumps(self.render_info['src_frames_path']),
-            '--output_path', pickle.dumps(self.render_info['movie_output_path']),
+            '--path_to_frames', pickle.dumps(self.render_info['src_frames_path']),
+            '--path_to_movie', pickle.dumps(self.render_info['movie_output_path']),
             '--extra_write_node_mapping', pickle.dumps(self.render_info['extra_write_node_mapping']),
             '--width', pickle.dumps(self.render_info['width']),
             '--height', pickle.dumps(self.render_info['height']),

--- a/python/tk_multi_reviewsubmission/renderer.py
+++ b/python/tk_multi_reviewsubmission/renderer.py
@@ -58,11 +58,8 @@ class Renderer(object):
             self._logo = self._logo.replace(os.sep, "/")
             self._burnin_nk = self._burnin_nk.replace(os.sep, "/")
 
-    def gather_nuke_render_info(self, path, output_path,
-                                width, height,
-                                first_frame, last_frame,
-                                version, name,
-                                color_space, burnin_nk):
+    def gather_nuke_render_info(self, path, output_path, extra_write_node_mapping, width, height, first_frame,
+                                last_frame, version, name, color_space, burnin_nk):
         # First get Nuke executable path from project configuration environment
         setting_key_by_os = {'win32': 'nuke_windows_path',
                              'linux2': 'nuke_linux_path',
@@ -117,22 +114,19 @@ class Renderer(object):
             'render_info': render_info,
             'src_frames_path': src_frames_path,
             'movie_output_path': movie_output_path,
+            'extra_write_node_mapping': extra_write_node_mapping,
         }
         return nuke_render_info
 
-    def render_movie_in_nuke(self, path, output_path,
-                             width, height,
-                             first_frame, last_frame,
-                             version, name,
-                             color_space,
-                             fields=None,
-                             active_progress_info=None):
+    def render_movie_in_nuke(self, path, output_path, extra_write_node_mapping, width, height, first_frame, last_frame,
+                             version, name, color_space, fields=None, active_progress_info=None):
         """
         Renders the movie using a Nuke subprocess,
         along with slate/burnins using all the app settings.
 
         :param path:            The path where frames should be found.
         :param output_path:     The path where the movie should be written to
+        :param extra_write_node_mapping: Mapping of write nodes other than the movie write node with their output paths
         :param width:           Movie width
         :param height:          Movie height
         :param first_frame:     The first frame of the sequence of frames
@@ -155,13 +149,13 @@ class Renderer(object):
                                                                     nuke_script_path=self._burnin_nk,
                                                                     fields=fields)
 
-        render_info = self.gather_nuke_render_info(path, output_path, width, height, first_frame,
-                                                   last_frame, version, name, color_space,
+        render_info = self.gather_nuke_render_info(path, output_path, extra_write_node_mapping, width, height,
+                                                   first_frame, last_frame, version, name, color_space,
                                                    processed_nuke_script_path)
         run_in_batch_mode = True if nuke is None else False
 
         event_loop = QtCore.QEventLoop()
-        thread = ShooterThread(render_info, run_in_batch_mode)
+        thread = ShooterThread(render_info, run_in_batch_mode, active_progress_info)
         thread.finished.connect(event_loop.quit)
         thread.start()
         event_loop.exec_()
@@ -179,6 +173,20 @@ class Renderer(object):
             # Make sure we don't display a success message. TODO: Custom exception?
             raise Exception("Error in tk-multi-reviewsubmission: " + subproc_traceback)
 
+        processed_paths = thread.get_processed_paths()
+        if not processed_paths:
+            raise Exception("Error in tk-multi-reviewsubmission: No output paths were found after the render!")
+
+        else:
+            # in the render hook we expect the thread to return us ':' separated paths
+            # return a list of paths
+            processed_paths_list = processed_paths.split(":")
+            for path in processed_paths_list:
+                active_progress_info(msg="Created %s" % path, stage={"item": {"name": "Render"},
+                                                                     "output": {"name": "Nuke"}})
+            return processed_paths_list
+
+
 class ShooterThread(QtCore.QThread):
     def __init__(self, render_info, batch_mode=True, active_progress_info=None):
         QtCore.QThread.__init__(self)
@@ -186,9 +194,13 @@ class ShooterThread(QtCore.QThread):
         self.batch_mode = batch_mode
         self.active_progress_info = active_progress_info
         self.subproc_error_msg = ''
+        self.processed_paths = ''
 
     def get_errors(self):
         return self.subproc_error_msg
+
+    def get_processed_paths(self):
+        return self.processed_paths
 
     def run(self):
         if self.batch_mode:
@@ -200,6 +212,7 @@ class ShooterThread(QtCore.QThread):
             self.render_info['nuke_exe_path'], nuke_flag, self.render_info['render_script_path'],
             '--path', pickle.dumps(self.render_info['src_frames_path']),
             '--output_path', pickle.dumps(self.render_info['movie_output_path']),
+            '--extra_write_node_mapping', pickle.dumps(self.render_info['extra_write_node_mapping']),
             '--width', pickle.dumps(self.render_info['width']),
             '--height', pickle.dumps(self.render_info['height']),
             '--version', pickle.dumps(self.render_info['version']),
@@ -216,12 +229,25 @@ class ShooterThread(QtCore.QThread):
         env["TANK_CONTEXT"] = self.render_info['serialized_context']
         p = subprocess.Popen(cmd_and_args, stderr=subprocess.PIPE, env=env, bufsize=1)
 
-        error_lines = []
+        output_lines = []
 
         while p.poll() is None:
-            stderr_line = p.stderr.readline()
-            if stderr_line != '':
-                error_lines.append(stderr_line.rstrip())
+            line = p.stderr.readline()
+            if line != '':
+                output_lines.append(line.rstrip())
+
+            # disable the active progress update, clutters the whole UI
+            # if line.startswith('Writing ') and self.active_progress_info:
+            #     # matching the _process_cb method of create_version.py
+            #     self.active_progress_info(msg=line.rstrip(), stage={"item": {"name": "Render"},
+            #                                                         "output": {"name": "Nuke"}})
 
         if p.returncode != 0:
-            self.subproc_error_msg = '\n'.join(error_lines)
+            output_str = '\n'.join(output_lines)
+            self.subproc_error_msg = output_str.split('[RETURN_STATUS_DATA]')[1]
+            del output_str
+        else:
+            # we should get the paths now!!
+            output_str = '\n'.join(output_lines)
+            self.processed_paths = output_str.split('[PROCESSED_PATHS]')[1]
+            del output_str

--- a/python/tk_multi_reviewsubmission/renderer.py
+++ b/python/tk_multi_reviewsubmission/renderer.py
@@ -189,12 +189,13 @@ class Renderer(object):
                 subproc_traceback = 'Traceback' + thread_error_msg.split('Traceback')[1]
             except IndexError:
                 subproc_traceback = thread_error_msg
-            # Make sure we don't display a success message. TODO: Custom exception?
-            raise Exception("Error in tk-multi-reviewsubmission: " + subproc_traceback)
+            # Make sure we don't display a success message.
+            raise NukeSubprocessFailed("Error in tk-multi-reviewsubmission: " + subproc_traceback)
 
         processed_paths = thread.get_processed_paths()
         if not processed_paths:
-            raise Exception("Error in tk-multi-reviewsubmission: No output paths were found after the render!")
+            raise NoProcessedPathsReturnedByNukeSubprocess("Error in tk-multi-reviewsubmission: "
+                                                           "No output paths were returned after the Nuke Render!")
 
         else:
             # in the render hook we expect the thread to return us ':' separated paths
@@ -202,8 +203,16 @@ class Renderer(object):
             processed_paths_list = processed_paths.split(":")
             for path_to_frames in processed_paths_list:
                 active_progress_info(msg="Created %s" % path_to_frames, stage={"item": {"name": "Render"},
-                                                                     "output": {"name": "Nuke"}})
+                                                                               "output": {"name": "Nuke"}})
             return processed_paths_list
+
+
+class NukeSubprocessFailed(Exception):
+    pass
+
+
+class NoProcessedPathsReturnedByNukeSubprocess(Exception):
+    pass
 
 
 class ShooterThread(QtCore.QThread):

--- a/python/tk_multi_reviewsubmission/submitter.py
+++ b/python/tk_multi_reviewsubmission/submitter.py
@@ -49,10 +49,9 @@ class Submitter(object):
             "sg_status_list": self.__app.get_setting("new_version_status"),
             "entity": ctx.entity,
             "sg_task": sg_task,
-            # Leaving these fields blank to enable correct rv playback
-            # and match LA shotgun
-            # "sg_first_frame": first_frame,
-            # "sg_last_frame": last_frame,
+            # reverting this back since artists now render the slate frames too.
+            "sg_first_frame": first_frame,
+            "sg_last_frame": last_frame,
             "frame_count": (last_frame-first_frame+1),
             "frame_range": "%s-%s" % (first_frame, last_frame),
             "sg_frames_have_slate": False,


### PR DESCRIPTION
[RETURN_STATUS_DATA] and [PROCESSED_PATHS] are now mandatory outputs to stderr of any nuke hook that gets written for review submit. It's output on stderr to avoid subprocess pipe going into a deadlock. actual exit status of the subprocess determines successful execution from an unsuccessful one.